### PR TITLE
add custom id property for editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ render(<App />, document.getElementById('app'))
 * `tools` `Object` configuration for the built-in and custom tools (default {})
 * `appearance` `Object` configuration for appearance and theme (default {})
 * `projectId` `Integer` Unlayer project ID (optional)
+* `id` `String` HTML id attribute passed to editor container for creating multiple editors on one page (default "editor")
 
 See the [Unlayer Docs](https://docs.unlayer.com/getting-started/) for all available options.
 

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ export default class extends Component {
         />
 
         <Editor
-          id="editor"
+          id={this.props.id || 'editor'}
           style={this.props.style}
           minHeight={this.props.minHeight}
         />
@@ -49,7 +49,7 @@ export default class extends Component {
     if (this.props.tools) {
       options.tools = this.props.tools
     }
-    
+
     if (this.props.appearance) {
       options.appearance = this.props.appearance
     }
@@ -57,10 +57,10 @@ export default class extends Component {
     if (this.props.locale) {
       options.locale = this.props.locale
     }
-    
+
     unlayer.init({
       ...options,
-      id: 'editor',
+      id: this.props.id || 'editor',
       displayMode: 'email',
     })
 


### PR DESCRIPTION
This is the same pull request, but without updating dependencies.

This PR allows us to pass an id prop when creating an editor. The previous implementation always used editor for the id which worked but caused issues when creating multiple editors on one page.

This PR fixes the issue by letting us pass a unique id prop to each editor, if no id prop is passed, the default is editor.

Simplified example of multiple editors:

```
export default class Example extends React.Component {
  render() {
      return (
          <Editor id="editor-1" />
          <Editor id="editor-2" />
      );
  }
}
```