### PR TITLE
Call onLoad callback only when editor it's loaded

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,9 +68,11 @@ export default class extends Component {
         this.addEventListener(key, value);
       }
     }
-
-    const { onLoad } = this.props;
-    onLoad && onLoad();
+    
+    this.editor.addEventListener('design:loaded', (data) => {
+      const { onLoad } = this.props;
+      onLoad && onLoad();
+    });
   };
 
   registerCallback = (type, callback) => {


### PR DESCRIPTION
If external editor script it's already loaded, the onLoad function is called too fast, before React could register any ref to rendered component. And this causes further updates on the email editor impossible.