### PR TITLE
add scriptUrl prop to load editor via on-premise js file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ export default class extends Component {
   }
 
   componentDidMount() {
-    loadScript(this.loadEditor);
+    loadScript(this.loadEditor, this.props.scriptUrl);
   }
 
   render() {

--- a/src/loadScript.js
+++ b/src/loadScript.js
@@ -1,8 +1,8 @@
-const scriptUrl = '//editor.unlayer.com/embed.js?2';
+const defaultScriptUrl = '//editor.unlayer.com/embed.js?2';
 const callbacks = [];
 let loaded = false;
 
-const isScriptInjected = () => {
+const isScriptInjected = (scriptUrl) => {
   const scripts = document.querySelectorAll('script');
   let injected = false;
 
@@ -29,10 +29,10 @@ const runCallbacks = () => {
   }
 };
 
-export const loadScript = (callback) => {
+export const loadScript = (callback, scriptUrl = defaultScriptUrl) => {
   addCallback(callback);
 
-  if (!isScriptInjected()) {
+  if (!isScriptInjected(scriptUrl)) {
     const embedScript = document.createElement('script');
     embedScript.setAttribute('src', scriptUrl);
     embedScript.onload = () => {


### PR DESCRIPTION
When using the unlayer editor on-premise, the embed.js file is self-hosted. 

This PR adds a new prop `sourceUrl` of type `string | undefined` to the unlayer editor that allows users to override the sourceUrl for unlayer.

Usage:
```
import EmailEditor from 'react-email-editor';
<EmailEditor
    ref={editorRef}
    projectId={...}
    appearance={...}
    tools={...}
    options={...}
    onLoad={...}
    scriptUrl={$ADD_CUSTOM_SCRIPT_URL_HERE}
/>
```