### PR TITLE
Removed deprecated onLoad from demo and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,12 @@ const App = (props) => {
     });
   };
 
-  const onLoad = () => {
-    // editor instance is created
+  const onReady = () => {
+    // editor is ready
     // you can load your template here;
     // const templateJson = {};
     // emailEditorRef.current.editor.loadDesign(templateJson);
-  }
-
-  const onReady = () => {
-    // editor is ready
+      
     console.log('onReady');
   };
 
@@ -61,7 +58,7 @@ const App = (props) => {
         <button onClick={exportHtml}>Export HTML</button>
       </div>
 
-      <EmailEditor ref={emailEditorRef} onLoad={onLoad} onReady={onReady} />
+      <EmailEditor ref={emailEditorRef} onReady={onReady} />
     </div>
   );
 };
@@ -84,7 +81,6 @@ See the [example source](https://github.com/unlayer/react-email-editor/blob/mast
 - `editorId` `String` HTML div id of the container where the editor will be embedded (optional)
 - `style` `Object` style object for the editor container (default {})
 - `minHeight` `String` minimum height to initialize the editor with (default 500px)
-- `onLoad` `Function` called when the editor instance is created
 - `onReady` `Function` called when the editor has finished loading
 - `options` `Object` options passed to the Unlayer editor instance (default {})
 - `tools` `Object` configuration for the built-in and custom tools (default {})

--- a/demo/src/example/index.js
+++ b/demo/src/example/index.js
@@ -61,19 +61,15 @@ const Example = (props) => {
     console.log('onDesignLoad', data);
   };
 
-  const onLoad = () => {
-    console.log('onLoad');
+  const onReady = () => {
+    console.log('onReady');
 
     emailEditorRef.current.editor.addEventListener(
-      'design:loaded',
-      onDesignLoad
+        'design:loaded',
+        onDesignLoad
     );
 
     emailEditorRef.current.editor.loadDesign(sample);
-  }
-
-  const onReady = () => {
-    console.log('onReady');
   };
 
   return (
@@ -86,7 +82,7 @@ const Example = (props) => {
       </Bar>
 
       <React.StrictMode>
-        <EmailEditor ref={emailEditorRef} onLoad={onLoad} onReady={onReady} />
+        <EmailEditor ref={emailEditorRef} onReady={onReady} />
       </React.StrictMode>
     </Container>
   );


### PR DESCRIPTION
The `onLoad` method has been marked as deprecated and should no longer be mentioned as the main way to load existing designs.

![Screenshot 2022-07-14 at 20 30 59](https://user-images.githubusercontent.com/31651090/179056505-9bb51ce1-0731-40c0-ae64-2917b9f7dba6.png)


It can even create weird situations when being used to load design in more modern frameworks, as seen in https://github.com/unlayer/react-email-editor/issues/211#issuecomment-1184761085

This pull request removes the mention of `onLoad` from both the README and demo.