### PR TITLE
fix: prevent editor from loading twice in react 18

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,8 @@ export default class extends Component {
   }
 
   loadEditor = () => {
+    if (this.loaded) return
+    this.loaded = true
     const options = this.props.options || {};
 
     if (this.props.projectId) {


### PR DESCRIPTION
fixes #241 