### PR TITLE
Add options param to exportHtml

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -95,8 +95,8 @@ export default class extends Component {
     this.editor.saveDesign(callback);
   };
 
-  exportHtml = (callback) => {
-    this.editor.exportHtml(callback);
+  exportHtml = (callback, options) => {
+    this.editor.exportHtml(callback, options);
   };
 
   setMergeTags = (mergeTags) => {


### PR DESCRIPTION
exportHtml accepts a list of options as a second param (https://docs.unlayer.com/docs/export-html#export-options).