### PR TITLE
Expose events in props

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,9 @@ type Props = {
   scriptUrl?: string;
   onReady?: Function;
   onLoad?: Function;
+  onDesignLoaded?: Function;
+  onDesignUpdated?: Function;
+  onImageUploaded?: Function;
   editorId?: string;
   projectId?: number;
   options?: EditorOptions;
@@ -27,7 +30,16 @@ type Props = {
 let lastEditorId = 0;
 
 const EmailEditor = (props: Props, ref: React.ForwardedRef<EditorRef>) => {
-  const { onLoad, onReady, scriptUrl, minHeight = 500, style = {} } = props;
+  const {
+    onLoad,
+    onReady,
+    onDesignLoaded,
+    onDesignUpdated,
+    onImageUploaded,
+    scriptUrl,
+    minHeight = 500,
+    style = {},
+  } = props;
 
   const editorId = useRef(props.editorId || `editor-${++lastEditorId}`);
   const isLoadedRef = useRef(false);
@@ -114,18 +126,32 @@ const EmailEditor = (props: Props, ref: React.ForwardedRef<EditorRef>) => {
   useEffect(() => {
     if (!editor) return;
 
-    // All properties starting with on[Name] are registered as event listeners.
-    for (const [key, value] of Object.entries(props)) {
-      if (/^on/.test(key) && key !== 'onLoad' && key !== 'onReady') {
-        addEventListener(key, value as Function);
-      }
-    }
-
     // @deprecated
     onLoad && onLoad();
 
     if (onReady) editor.addEventListener('editor:ready', onReady);
-  }, [editor, addEventListener, onLoad, onReady, props]);
+  }, [editor, addEventListener, onLoad, onReady]);
+
+  useEffect(() => {
+    if (!editor) return;
+
+    if (onDesignLoaded)
+      editor.addEventListener('design:loaded', onDesignLoaded);
+  }, [editor, addEventListener, onDesignLoaded]);
+
+  useEffect(() => {
+    if (!editor) return;
+
+    if (onDesignUpdated)
+      editor.addEventListener('design:updated', onDesignUpdated);
+  }, [editor, addEventListener, onDesignUpdated]);
+
+  useEffect(() => {
+    if (!editor) return;
+
+    if (onImageUploaded)
+      editor.addEventListener('image:uploaded', onImageUploaded);
+  }, [editor, addEventListener, onImageUploaded]);
 
   useImperativeHandle(
     ref,


### PR DESCRIPTION
Currently it's possible to attach events by passing onXXXXX properties. However, it doesn't work in case of events like `image:uploaded` or `design:updated`. Also, it's tricky with typescript. Previously, the addEventListeners was being exposed in the ref but it was removed. I'm proposing we explicitly allow the events via props. Lemme know your thoughts.

```ts
<EmailEditor onDesignLoaded={.....} />
```

```ts
<EmailEditor onDesignUpdated={.....} />
```

```ts
<EmailEditor onImageUploaded={.....} />
```