### PR TITLE
broken default export in cjs

### DIFF
--- a/src/EmailEditor.tsx
+++ b/src/EmailEditor.tsx
@@ -24,7 +24,7 @@ import { loadScript } from './loadScript';
 
 let lastEditorId = 0;
 
-export const EmailEditor = React.forwardRef<EditorRef, EmailEditorProps>(
+const EmailEditor = React.forwardRef<EditorRef, EmailEditorProps>(
   (props, ref) => {
     const { onLoad, onReady, scriptUrl, minHeight = 500, style = {} } = props;
 
@@ -170,3 +170,5 @@ export const EmailEditor = React.forwardRef<EditorRef, EmailEditorProps>(
     );
   }
 );
+
+export default EmailEditor;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { EmailEditor } from './EmailEditor';
+import EmailEditor from './EmailEditor';
 
 export * from './types';
 export default EmailEditor;


### PR DESCRIPTION
For some reason tsdx makes a named export default. This breaks environments where cjs is used.

temp workaround is using default export.

Note: TSDX is unmaintained.


> The problem is in the current release: `dist/react-email-editor.cjs.development.js:232`
should be `exports.EmailEditor = EmailEditor;` but it is `exports.default = EmailEditor;`