### PR TITLE
Add signature to user type (UnlayerOptions)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export interface User {
   id?: number | undefined;
   name?: string | undefined;
   email?: string | undefined;
+  signature?: string | undefined;
 }
 
 export interface GroupedSpecialLink {


### PR DESCRIPTION
resolves #327

By adding signature to the User type, a signature can be passed through the user property on the EmailEditor component, allowing the user verification feature to work.