### PR TITLE
Add missing type smartMergeTags on UnlayerOptions

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -108,6 +108,7 @@ export interface Features {
   stockImages?: boolean | undefined;
   textEditor?: TextEditor | undefined;
   ai?: boolean | AiFeatures;
+  smartMergeTags?: boolean | undefined;
 }
 
 export interface TextEditor {


### PR DESCRIPTION
Add `smartMergeTags` to the `Features` type.

https://docs.unlayer.com/docs/merge-tags#smart-merge-tags