### PR TITLE
Fix for server-side-rendering (NextJS). Window is now only accessed in a useEffect

### DIFF
--- a/src/EmailEditor.tsx
+++ b/src/EmailEditor.tsx
@@ -68,7 +68,7 @@ export const EmailEditor = React.forwardRef<EditorRef, EmailEditorProps>(
         };
       editor?.destroy();
       setEditor(unlayer.createEditor(options));
-    }, [props?.options, hasLoadedEmbedScript, editorId]);
+    }, [JSON.stringify(props?.options), hasLoadedEmbedScript, editorId]);
 
     const methodProps = Object.keys(props).filter((propName) =>
       /^on/.test(propName)

--- a/src/EmailEditor.tsx
+++ b/src/EmailEditor.tsx
@@ -2,14 +2,12 @@ import React, {
   useEffect,
   useState,
   useImperativeHandle,
-  useMemo,
 } from 'react';
 
 import pkg from '../package.json';
 import { Editor, EditorRef, EmailEditorProps } from './types';
 import { loadScript } from './loadScript';
 
-window.__unlayer_lastEditorId = window.__unlayer_lastEditorId || 0;
 
 export const EmailEditor = React.forwardRef<EditorRef, EmailEditorProps>(
   (props, ref) => {
@@ -17,27 +15,21 @@ export const EmailEditor = React.forwardRef<EditorRef, EmailEditorProps>(
 
     const [editor, setEditor] = useState<Editor | null>(null);
 
+    const [editorId, setEditorId] = useState<string | undefined>(undefined);
+
     const [hasLoadedEmbedScript, setHasLoadedEmbedScript] = useState(false);
 
-    const editorId = useMemo(
-      () => props.editorId || `editor-${++window.__unlayer_lastEditorId}`,
-      [props.editorId]
-    );
 
-    const options: EmailEditorProps['options'] = {
-      ...(props.options || {}),
-      appearance: props.appearance ?? props.options?.appearance,
-      displayMode: props?.displayMode || props.options?.displayMode || 'email',
-      locale: props.locale ?? props.options?.locale,
-      projectId: props.projectId ?? props.options?.projectId,
-      tools: props.tools ?? props.options?.tools,
 
-      id: editorId,
-      source: {
-        name: pkg.name,
-        version: pkg.version,
-      },
-    };
+    // const editorId = useMemo(
+    //   () => props.editorId || `editor-${++window.__unlayer_lastEditorId}`,
+    //   [props.editorId]
+    // );
+    //
+    useEffect(() => {
+        window.__unlayer_lastEditorId = window.__unlayer_lastEditorId || 0;
+        setEditorId(props.editorId || `editor-${++window.__unlayer_lastEditorId}`)
+    }, [props.editorId])
 
     useImperativeHandle(
       ref,
@@ -59,10 +51,24 @@ export const EmailEditor = React.forwardRef<EditorRef, EmailEditorProps>(
     }, [scriptUrl]);
 
     useEffect(() => {
-      if (!hasLoadedEmbedScript) return;
+      if (!hasLoadedEmbedScript || !editorId) return;
+        const options: EmailEditorProps['options'] = {
+            ...(props.options || {}),
+            appearance: props.appearance ?? props.options?.appearance,
+            displayMode: props?.displayMode || props.options?.displayMode || 'email',
+            locale: props.locale ?? props.options?.locale,
+            projectId: props.projectId ?? props.options?.projectId,
+            tools: props.tools ?? props.options?.tools,
+
+            id: editorId,
+            source: {
+                name: pkg.name,
+                version: pkg.version,
+            },
+        };
       editor?.destroy();
       setEditor(unlayer.createEditor(options));
-    }, [JSON.stringify(options), hasLoadedEmbedScript]);
+    }, [props?.options, hasLoadedEmbedScript, editorId]);
 
     const methodProps = Object.keys(props).filter((propName) =>
       /^on/.test(propName)


### PR DESCRIPTION
The problem: 
When using NextJS and server-side-rendering (SSR) the program crashes because the window object is beeing accessed outside of useEffects.

Possible solutions/hacks:
Using dynamic imports. However this causes new problems becuase you need to have a ref to the editor. It is far from straight-forward how to get around this and I tried but it causes other problems such as callbacks not beeing called etc.
You can try following this guide to fix it:
https://github.com/vercel/next.js/issues/4957

Actual solution:
Make sure you only access the window/document object inside a useEffect